### PR TITLE
Add Dockerfile, docker-compose, Makefile, tests and dev instructions (issue #13)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,31 @@
+# Development / local run
+
+This repository contains a small FastAPI app under `src/`. The following files have been added to make local development easier:
+
+- `Dockerfile` - container image for running the FastAPI app
+- `docker-compose.yml` - compose file to run the app locally on port 8000
+- `Makefile` - convenience targets: `make build`, `make up`, `make down`, `make test`
+- `requirements-dev.txt` - dev/test dependencies (pytest, requests)
+- `tests/` - contains minimal pytest tests
+
+Quick start (requires Docker):
+
+1. Build and run using docker-compose:
+
+   docker-compose up --build
+
+2. Visit http://localhost:8000 in your browser (the UI is served under `/static/index.html`).
+
+Running tests locally (without Docker):
+
+1. Create a virtualenv and install dependencies:
+
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt -r requirements-dev.txt
+
+2. Run tests:
+
+   pytest -q
+
+If you'd like, I can now create a branch, commit these changes, run the tests here, and push + open a PR. Tell me to continue and I'll do the git steps next.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install build deps and pip requirements
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source
+COPY src/ ./src
+
+EXPOSE 8000
+
+CMD ["uvicorn", "src.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+PYTHON?=python3
+
+.PHONY: help build up down test
+
+help:
+	@echo "Targets: build, up, down, test"
+
+build:
+	docker build -t skills-integrate-mcp:local .
+
+up:
+	docker-compose up --build
+
+down:
+	docker-compose down
+
+test:
+	${PYTHON} -m pytest -q

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./src:/app/src
+      - ./requirements.txt:/app/requirements.txt:ro
+    environment:
+      - PYTHONUNBUFFERED=1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 requests
+httpx

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+from src.app import app
+
+
+client = TestClient(app)
+
+
+def test_get_activities():
+    resp = client.get("/activities")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+    # spot check an expected activity
+    assert "Chess Club" in data
+
+
+def test_root_redirect_and_static():
+    resp = client.get("/")
+    # root redirects to /static/index.html, TestClient may return 307/308
+    assert resp.status_code in (200, 307, 308)
+    resp2 = client.get("/static/index.html")
+    assert resp2.status_code == 200

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,9 @@
+import os
+import sys
 from fastapi.testclient import TestClient
+
+# Ensure repo root is on sys.path so we can import `src` package
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from src.app import app
 
 


### PR DESCRIPTION
This PR adds development setup files for local testing and reproducible dev environment:
- Dockerfile for FastAPI app
- docker-compose.yml for local run
- Makefile for common dev tasks
- requirements-dev.txt for pytest, requests, httpx
- tests/ with minimal FastAPI endpoint tests
- DEVELOPMENT.md with instructions

All tests pass locally. See DEVELOPMENT.md for usage.

Closes #13.